### PR TITLE
Fix LED king color indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,9 @@ This project isn’t just a chess engine—it’s a blueprint for building lean,
 
 ## License
 MicroChess is licensed under the MIT License. See the [LICENSE](https://github.com/ripred/MicroChess/blob/main/LICENSE) file for details.
+
+## Bug Fixes
+
+- **LED Strip King Colors**: Kings were sometimes displayed with incorrect LED colors
+  because the color lookup indexed beyond the end of the color table. The index
+  now wraps correctly so both white and black kings use the right colors.

--- a/led_strip.cpp
+++ b/led_strip.cpp
@@ -66,7 +66,12 @@ void set_led_strip(index_t const flash /* = -1 */)
             static index_t constexpr values_per_led  = index_t(3);
             static index_t constexpr values_per_side = index_t(sizeof(piece_colors) / 2);
 
-            clr = (vars.type * values_per_led) + (vars.side * values_per_side);
+            // There are only six color definitions per side in piece_colors.
+            // Piece type values range from 0 (Empty) to 6 (King) so using the
+            // raw type value would index beyond the table for Kings.
+            // Mod the type by six to keep the index within bounds.
+            clr = ((vars.type % 6) * values_per_led) +
+                  (vars.side * values_per_side);
 
             leds[vars.led_index] = (Empty == vars.type) ? 
                 // empty spots


### PR DESCRIPTION
## Summary
- fix out-of-bounds access in LED color lookup
- document the LED color bug fix in README

## Testing
- `npm test` *(fails: package.json missing)*
- `make test`
- `ctest` *(fails: no configuration)*
- `pytest` *(fails: command not found)*